### PR TITLE
Fix UI namespace for wix_creator_dev

### DIFF
--- a/wix_creator_dev.py
+++ b/wix_creator_dev.py
@@ -297,7 +297,7 @@ def create_wxs_file(output_dir, options, file_structure):
         ET.SubElement(package, "UIRef", Id="WixUI_InstallDir")
 
         # Create an element to hold custom UI modifications
-        ui_element = ET.SubElement(package, "UI")
+        ui_element = ET.SubElement(package, ET.QName(UI_NS, "UI"))
 
         # Add custom UI dialog for installation options
         dialog = ET.SubElement(ui_element, ET.QName(UI_NS, "Dialog"),


### PR DESCRIPTION
## Summary
- fix UI element to use the ui namespace

## Testing
- `python3 -m py_compile wix_creator_dev.py`

------
https://chatgpt.com/codex/tasks/task_e_68419dfd14f08321b3153b88c02860ff