### PR TITLE
Fix: Correct placement of custom UI elements in WiX generation

### DIFF
--- a/wix_creator_dev.py
+++ b/wix_creator_dev.py
@@ -296,11 +296,8 @@ def create_wxs_file(output_dir, options, file_structure):
         # Reference the built-in InstallDir UI
         ET.SubElement(package, "UIRef", Id="WixUI_InstallDir")
 
-        # Create an element to hold custom UI modifications
-        ui_element = ET.SubElement(package, ET.QName(UI_NS, "UI"))
-
         # Add custom UI dialog for installation options
-        dialog = ET.SubElement(ui_element, ET.QName(UI_NS, "Dialog"),
+        dialog = ET.SubElement(package, ET.QName(UI_NS, "Dialog"),
                      Id="InstallOptionsDialog",
                      Width="370",
                      Height="270",
@@ -383,66 +380,66 @@ def create_wxs_file(output_dir, options, file_structure):
                      Text="Cancel")
 
         # Insert the dialog in the UI sequence
-        ET.SubElement(ui_element, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallOptionsDialog",
                      Control="Back", 
                      Event="NewDialog", 
                      Value="LicenseAgreementDlg")
 
-        ET.SubElement(ui_element, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallOptionsDialog",
                      Control="Next", 
                      Event="NewDialog", 
                      Value="InstallDirDlg")
 
-        ET.SubElement(ui_element, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
                      Dialog="LicenseAgreementDlg",
                      Control="Next",
                      Event="NewDialog",
                      Value="InstallOptionsDialog")
 
-        ET.SubElement(ui_element, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallDirDlg",
                      Control="Back",
                      Event="NewDialog",
                      Value="InstallOptionsDialog")
 
         # Add Cancel button event
-        ET.SubElement(ui_element, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallOptionsDialog",
                      Control="Cancel",
                      Event="SpawnDialog",
                      Value="CancelDlg")
 
         # Add events for InstallDirDlg buttons to fix ICE17 errors
-        ET.SubElement(ui_element, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallDirDlg",
                      Control="Next",
                      Event="SetTargetPath",
                      Value="[WIXUI_INSTALLDIR]")
 
-        ET.SubElement(ui_element, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallDirDlg",
                      Control="Next",
                      Event="DoAction",
                      Value="WixUIValidatePath",
                      Condition="NOT WIXUI_DONTVALIDATEPATH")
 
-        ET.SubElement(ui_element, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallDirDlg",
                      Control="Next", 
                      Event="SpawnDialog", 
                      Value="InvalidDirDlg",
                      Condition="WIXUI_INSTALLDIR_VALID<>\"1\"")
 
-        ET.SubElement(ui_element, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallDirDlg",
                      Control="Next", 
                      Event="NewDialog", 
                      Value="VerifyReadyDlg",
                      Condition="WIXUI_INSTALLDIR_VALID=\"1\"")
 
-        ET.SubElement(ui_element, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallDirDlg",
                      Control="ChangeFolder", 
                      Event="SpawnDialog", 


### PR DESCRIPTION
The script `wix_creator_dev.py` was generating a <ui:UI> element as a direct child of the <Package> element when adding custom dialogs to the WixUI_InstallDir sequence. This is incorrect and leads to the WIX0005 error ("The Package element contains an unexpected child element 'UI'") during the WiX build process.

This commit modifies `wix_creator_dev.py` to remove the erroneous <ui:UI> wrapper. The custom <ui:Dialog> (for InstallOptionsDialog) and its associated <ui:Publish> elements are now generated as direct children of the <Package> element. These elements still use the correct 'ui' namespace.

This change ensures that your custom UI definitions correctly integrate with the standard WixUI_InstallDir dialog set, as per common WiX v4 practices for UI customization. The <UIRef Id="WixUI_InstallDir"/> is retained, and the custom dialogs will now correctly sequence into this predefined UI flow.