### PR TITLE
Fix: Correct WiX UI element structure in wix_creator_dev.py

### DIFF
--- a/wix_creator_dev.py
+++ b/wix_creator_dev.py
@@ -272,6 +272,9 @@ def create_wxs_file(output_dir, options, file_structure):
                            Version=options['product_version'],
                            UpgradeCode=options['upgrade_code'])
 
+    # Create the UI element
+    ui_element = ET.SubElement(package, "UI")
+
     # Add UI properties for installation options
     if options['ui_level'] in ['full', 'minimal']:
         # Property for desktop shortcut
@@ -294,10 +297,10 @@ def create_wxs_file(output_dir, options, file_structure):
         ET.SubElement(package, "Property", Id="WIXUI_INSTALLDIR", Value="INSTALLDIR")
 
         # Reference the built-in InstallDir UI
-        ET.SubElement(package, "UIRef", Id="WixUI_InstallDir")
+        ET.SubElement(ui_element, "UIRef", Id="WixUI_InstallDir")
 
         # Add custom UI dialog for installation options
-        dialog = ET.SubElement(package, ET.QName(UI_NS, "Dialog"),
+        dialog = ET.SubElement(ui_element, ET.QName(UI_NS, "Dialog"),
                      Id="InstallOptionsDialog",
                      Width="370",
                      Height="270",
@@ -379,67 +382,70 @@ def create_wxs_file(output_dir, options, file_structure):
                      Cancel="yes", 
                      Text="Cancel")
 
+        # Create InstallUISequence element
+        install_ui_sequence = ET.SubElement(ui_element, "InstallUISequence")
+
         # Insert the dialog in the UI sequence
-        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(install_ui_sequence, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallOptionsDialog",
                      Control="Back", 
                      Event="NewDialog", 
                      Value="LicenseAgreementDlg")
 
-        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(install_ui_sequence, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallOptionsDialog",
                      Control="Next", 
                      Event="NewDialog", 
                      Value="InstallDirDlg")
 
-        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(install_ui_sequence, ET.QName(UI_NS, "Publish"),
                      Dialog="LicenseAgreementDlg",
                      Control="Next",
                      Event="NewDialog",
                      Value="InstallOptionsDialog")
 
-        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(install_ui_sequence, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallDirDlg",
                      Control="Back",
                      Event="NewDialog",
                      Value="InstallOptionsDialog")
 
         # Add Cancel button event
-        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(install_ui_sequence, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallOptionsDialog",
                      Control="Cancel",
                      Event="SpawnDialog",
                      Value="CancelDlg")
 
         # Add events for InstallDirDlg buttons to fix ICE17 errors
-        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(install_ui_sequence, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallDirDlg",
                      Control="Next",
                      Event="SetTargetPath",
                      Value="[WIXUI_INSTALLDIR]")
 
-        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(install_ui_sequence, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallDirDlg",
                      Control="Next",
                      Event="DoAction",
                      Value="WixUIValidatePath",
                      Condition="NOT WIXUI_DONTVALIDATEPATH")
 
-        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(install_ui_sequence, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallDirDlg",
                      Control="Next", 
                      Event="SpawnDialog", 
                      Value="InvalidDirDlg",
                      Condition="WIXUI_INSTALLDIR_VALID<>\"1\"")
 
-        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(install_ui_sequence, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallDirDlg",
                      Control="Next", 
                      Event="NewDialog", 
                      Value="VerifyReadyDlg",
                      Condition="WIXUI_INSTALLDIR_VALID=\"1\"")
 
-        ET.SubElement(package, ET.QName(UI_NS, "Publish"),
+        ET.SubElement(install_ui_sequence, ET.QName(UI_NS, "Publish"),
                      Dialog="InstallDirDlg",
                      Control="ChangeFolder", 
                      Event="SpawnDialog", 


### PR DESCRIPTION
The script wix_creator_dev.py was generating WiX XML where UI elements like custom Dialogs and Publish tags were direct children of the Package element. This could lead to WIX0005 errors ("The Package element contains an unexpected child element 'UI'").

This commit refactors the XML generation in `create_wxs_file` to:
- Create a top-level <UI> element under <Package>.
- Move <UIRef Id="WixUI_InstallDir"/> into the <UI> element.
- Move custom <Dialog> definitions into the <UI> element.
- Create an <InstallUISequence> element within <UI>.
- Move all <Publish> tags (dialog sequencing) into the <InstallUISequence> element.

These changes align with standard WiX schema practices for defining custom user interfaces and should resolve the WIX0005 error when building the generated .wxs file in an environment where WiX extensions are correctly located.