### PR TITLE
Fix WiX build errors

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -58,9 +58,14 @@ If you run the script from the project directory, it will automatically look for
 
 It does this magic by looking for "last_project.json" in the current directory, which is created by the script when it runs. This file is always identical to the last generated "<Product Name>.json" file, so you can use it to quickly rerun the script without needing to specify all parameters again.
 
-Then build the installer using the generated WiX XML file:
+Then build the installer using the generated project file:
 ```powershell
-wix build -ext WixToolset.UI.wixext -ext WixToolset.Util.wixext .\Installer\MeshForge.wxs
+dotnet build .\Installer\MeshForge.wixproj
 ```
 
-This command includes the necessary UI and Util extensions required for the installer. Without these extensions, you may encounter errors related to unhandled extension elements or illegal identifiers with namespace prefixes.
+You can also use `wix build` if you prefer:
+```powershell
+wix build .\Installer\MeshForge.wixproj
+```
+
+Both commands automatically include the required UI and Util extensions when using the project file and avoid preprocessor variable errors.

--- a/wix_creator.py
+++ b/wix_creator.py
@@ -314,27 +314,22 @@ def create_wixproj_file(output_dir, options):
     """Create the .wixproj file for the WiX project."""
     wixproj_path = os.path.join(output_dir, f"{options['product_name']}.wixproj")
 
-    # Create the root element
-    project = ET.Element("Project", 
-                        DefaultTargets="Build",
-                        xmlns="http://schemas.microsoft.com/developer/msbuild/2003",
-                        ToolsVersion="4.0")
+    # Use the WiX SDK style project so wix build works without extra properties
+    project = ET.Element("Project", Sdk="WixToolset.Sdk/6.0.0")
 
-    # Add property group
+    # Property group with minimal required settings
     property_group = ET.SubElement(project, "PropertyGroup")
-    ET.SubElement(property_group, "Configuration").text = "Debug"
-    ET.SubElement(property_group, "Platform").text = "x86"
-    ET.SubElement(property_group, "ProductVersion").text = options['product_version']
-    ET.SubElement(property_group, "SchemaVersion").text = "2.0"
     ET.SubElement(property_group, "OutputName").text = options['product_name']
     ET.SubElement(property_group, "OutputType").text = "Package"
 
-    # Add item group for project references
+    # Include the main .wxs file
     item_group = ET.SubElement(project, "ItemGroup")
-    compile = ET.SubElement(item_group, "Compile", Include=f"{options['product_name']}.wxs")
+    ET.SubElement(item_group, "Compile", Include=f"{options['product_name']}.wxs")
 
-    # Add import for WiX targets
-    ET.SubElement(project, "Import", Project="$(WixTargetsPath)", Condition="Exists('$(WixTargetsPath)')")
+    # Always reference the UI and Util extensions for compatibility
+    extensions_group = ET.SubElement(project, "ItemGroup")
+    ET.SubElement(extensions_group, "WixExtension", Include="WixToolset.UI.wixext")
+    ET.SubElement(extensions_group, "WixExtension", Include="WixToolset.Util.wixext")
 
     # Write the XML to file with proper formatting
     rough_string = ET.tostring(project, 'utf-8')

--- a/wix_creator_dev.py
+++ b/wix_creator_dev.py
@@ -731,32 +731,22 @@ def create_wixproj_file(output_dir, options):
     """Create the .wixproj file for the WiX project."""
     wixproj_path = os.path.join(output_dir, f"{options['product_name']}.wixproj")
 
-    # Create the root element
-    project = ET.Element("Project", 
-                        DefaultTargets="Build",
-                        xmlns="http://schemas.microsoft.com/developer/msbuild/2003",
-                        ToolsVersion="4.0")
+    # Use the WiX SDK style project so "wix build" works correctly
+    project = ET.Element("Project", Sdk="WixToolset.Sdk/6.0.0")
 
-    # Add property group
+    # Minimal property group
     property_group = ET.SubElement(project, "PropertyGroup")
-    ET.SubElement(property_group, "Configuration").text = "Debug"
-    ET.SubElement(property_group, "Platform").text = "x86"
-    ET.SubElement(property_group, "ProductVersion").text = options['product_version']
-    ET.SubElement(property_group, "SchemaVersion").text = "2.0"
     ET.SubElement(property_group, "OutputName").text = options['product_name']
     ET.SubElement(property_group, "OutputType").text = "Package"
 
-    # Add item group for project references
+    # Compile item for main wxs file
     item_group = ET.SubElement(project, "ItemGroup")
-    compile = ET.SubElement(item_group, "Compile", Include=f"{options['product_name']}.wxs")
+    ET.SubElement(item_group, "Compile", Include=f"{options['product_name']}.wxs")
 
-    # Add item group for WiX extensions
+    # Always include UI and Util extensions
     extensions_group = ET.SubElement(project, "ItemGroup")
     ET.SubElement(extensions_group, "WixExtension", Include="WixToolset.UI.wixext")
     ET.SubElement(extensions_group, "WixExtension", Include="WixToolset.Util.wixext")
-
-    # Add import for WiX targets
-    ET.SubElement(project, "Import", Project="$(WixTargetsPath)", Condition="Exists('$(WixTargetsPath)')")
 
     # Write the XML to file with proper formatting
     rough_string = ET.tostring(project, 'utf-8')


### PR DESCRIPTION
## Summary
- use WiX SDK project style when generating wixproj files
- clarify installer build instructions in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d8eda8c08321a4dcb7f46b29b411