### PR TITLE
Fix wix build output path

### DIFF
--- a/wix_creator_dev.py
+++ b/wix_creator_dev.py
@@ -738,6 +738,8 @@ def create_wixproj_file(output_dir, options):
     property_group = ET.SubElement(project, "PropertyGroup")
     ET.SubElement(property_group, "OutputName").text = options['product_name']
     ET.SubElement(property_group, "OutputType").text = "Package"
+    # Use a fixed output path so wix build does not require $(Configuration)
+    ET.SubElement(property_group, "OutputPath").text = "bin\\"
 
     # Compile item for main wxs file
     item_group = ET.SubElement(project, "ItemGroup")


### PR DESCRIPTION
## Summary
- ensure `wix build` succeeds by writing a constant `OutputPath` in `wix_creator_dev.py`

## Testing
- `python -m py_compile wix_creator_dev.py`


------
https://chatgpt.com/codex/tasks/task_e_6841de2feac08321b6a3594214efe72a