### PR TITLE
Fix wixproj generation

### DIFF
--- a/wix_creator_dev.py
+++ b/wix_creator_dev.py
@@ -732,7 +732,13 @@ def create_wixproj_file(output_dir, options):
     wixproj_path = os.path.join(output_dir, f"{options['product_name']}.wixproj")
 
     # Use the WiX SDK style project so "wix build" works correctly
-    project = ET.Element("Project", Sdk="WixToolset.Sdk/6.0.0")
+    project = ET.Element(
+        "Project",
+        {
+            "Sdk": "WixToolset.Sdk/6.0.0",
+            "xmlns": "http://schemas.microsoft.com/developer/msbuild/2003",
+        },
+    )
 
     # Minimal property group
     property_group = ET.SubElement(project, "PropertyGroup")


### PR DESCRIPTION
## Summary
- tweak wix_creator_dev.py to embed MSBuild XML namespace when generating wixproj files

## Testing
- `python -m py_compile wix_creator_dev.py`

------
https://chatgpt.com/codex/tasks/task_e_6841e16bb6f08321bdf2570bbcc46ff3