### PR TITLE
Fix wixproj generation in dev tool

### DIFF
--- a/wix_creator_dev.py
+++ b/wix_creator_dev.py
@@ -734,10 +734,7 @@ def create_wixproj_file(output_dir, options):
     # Use the WiX SDK style project so "wix build" works correctly
     project = ET.Element(
         "Project",
-        {
-            "Sdk": "WixToolset.Sdk/6.0.0",
-            "xmlns": "http://schemas.microsoft.com/developer/msbuild/2003",
-        },
+        {"Sdk": "WixToolset.Sdk/6.0.0"},
     )
 
     # Minimal property group


### PR DESCRIPTION
## Summary
- generate SDK-style .wixproj without MSBuild namespace

## Testing
- `python3 -m py_compile wix_creator_dev.py wix_creator.py`


------
https://chatgpt.com/codex/tasks/task_e_68421573bda48321b7224195025076e4