### PR TITLE
Fix UI namespace for WiX output

### DIFF
--- a/Installer/MeshForge.wxs
+++ b/Installer/MeshForge.wxs
@@ -1,9 +1,9 @@
 <?xml version="1.0" ?>
 <Wix xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui" xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package Name="MeshForge" Manufacturer="Leland Green Productions" Version="1.0.11" UpgradeCode="21379429-9f0c-432d-bff1-101e77fc02c1">
-    <UI>
-      <UIRef Id="ProductUI"/>
-    </UI>
+    <ui:UI>
+      <ui:UIRef Id="ProductUI"/>
+    </ui:UI>
     <Property Id="INSTALLDESKTOPSHORTCUT" Value="1"/>
     <Property Id="INSTALLSTARTMENUSHORTCUT" Value="1"/>
     <Property Id="LAUNCHAPPONEXIT" Value="0"/>
@@ -1602,8 +1602,8 @@
     <Property Id="ARPPRODUCTICON" Value="ProductIcon"/>
   </Package>
   <Fragment>
-    <UI Id="ProductUI">
-      <UIRef Id="WixUI_InstallDir"/>
+    <ui:UI Id="ProductUI">
+      <ui:UIRef Id="WixUI_InstallDir"/>
       <ui:Dialog Id="InstallOptionsDialog" Width="370" Height="270" Title="Installation Options">
         <ui:Control Id="DesktopShortcutCheckbox" Type="CheckBox" X="20" Y="60" Width="330" Height="17" Property="INSTALLDESKTOPSHORTCUT" CheckBoxValue="1" TabSkip="no" Text="Create a shortcut on the desktop"/>
         <ui:Control Id="StartMenuShortcutCheckbox" Type="CheckBox" X="20" Y="80" Width="330" Height="17" Property="INSTALLSTARTMENUSHORTCUT" CheckBoxValue="1" Text="Create a shortcut in the Start Menu"/>
@@ -1623,6 +1623,6 @@
       <ui:Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Condition="WIXUI_INSTALLDIR_VALID&lt;&gt;&quot;1&quot;"/>
       <ui:Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Condition="WIXUI_INSTALLDIR_VALID=&quot;1&quot;"/>
       <ui:Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg"/>
-    </UI>
+    </ui:UI>
   </Fragment>
 </Wix>

--- a/wix_creator_dev.py
+++ b/wix_creator_dev.py
@@ -274,11 +274,11 @@ def create_wxs_file(output_dir, options, file_structure):
 
     # Create a new Fragment element to hold custom UI modifications
     fragment = ET.SubElement(wix, "Fragment")
-    fragment_ui = ET.SubElement(fragment, "UI", Id="ProductUI")
+    fragment_ui = ET.SubElement(fragment, ET.QName(UI_NS, "UI"), Id="ProductUI")
 
     # Create the UI element within the package that references our custom UI
-    ui_element = ET.SubElement(package, "UI")
-    ET.SubElement(ui_element, "UIRef", Id="ProductUI")
+    ui_element = ET.SubElement(package, ET.QName(UI_NS, "UI"))
+    ET.SubElement(ui_element, ET.QName(UI_NS, "UIRef"), Id="ProductUI")
 
     # Add UI properties for installation options
     if options['ui_level'] in ['full', 'minimal']:
@@ -302,7 +302,7 @@ def create_wxs_file(output_dir, options, file_structure):
         ET.SubElement(package, "Property", Id="WIXUI_INSTALLDIR", Value="INSTALLDIR")
 
         # Reference the built-in InstallDir UI from our custom UI fragment
-        ET.SubElement(fragment_ui, "UIRef", Id="WixUI_InstallDir")
+        ET.SubElement(fragment_ui, ET.QName(UI_NS, "UIRef"), Id="WixUI_InstallDir")
 
         # Add custom UI dialog for installation options (now under our custom UI fragment)
         dialog = ET.SubElement(fragment_ui, ET.QName(UI_NS, "Dialog"),


### PR DESCRIPTION
## Summary
- correct UI namespace usage in `wix_creator_dev.py`
- update generated `MeshForge.wxs` to use `ui:` namespace

## Testing
- `python -m py_compile wix_creator_dev.py`
- `python -m py_compile wix_creator.py`


------
https://chatgpt.com/codex/tasks/task_e_684219f2d1fc83218c6d5a87d55effef