### PR TITLE
Fix Publish placement in custom UI

### DIFF
--- a/wix_creator_dev.py
+++ b/wix_creator_dev.py
@@ -384,16 +384,20 @@ def create_wxs_file(output_dir, options, file_structure):
                      Cancel="yes", 
                      Text="Cancel")
 
-        # Publish elements for InstallOptionsDialog navigation (now children of the Dialog)
-        ET.SubElement(dialog, "Publish",
+        # Publish elements for InstallOptionsDialog navigation
+        # These must be under the UI fragment rather than the Dialog
+        ET.SubElement(fragment_ui, "Publish",
+                     Dialog="InstallOptionsDialog",
                      Control="Back",
                      Event="NewDialog",
                      Value="LicenseAgreementDlg")
-        ET.SubElement(dialog, "Publish",
+        ET.SubElement(fragment_ui, "Publish",
+                     Dialog="InstallOptionsDialog",
                      Control="Next",
                      Event="NewDialog",
                      Value="InstallDirDlg")
-        ET.SubElement(dialog, "Publish",
+        ET.SubElement(fragment_ui, "Publish",
+                     Dialog="InstallOptionsDialog",
                      Control="Cancel",
                      Event="SpawnDialog",
                      Value="CancelDlg")


### PR DESCRIPTION
## Summary
- ensure Publish elements for InstallOptionsDialog are added under the UI fragment instead of the Dialog

## Testing
- `python3 -m py_compile wix_creator_dev.py`

------
https://chatgpt.com/codex/tasks/task_e_6842cfbcbc408321bc6b06e150344607